### PR TITLE
Temporary: don't render all txns for performace reasons

### DIFF
--- a/lib/MainContainer.js
+++ b/lib/MainContainer.js
@@ -154,7 +154,6 @@ export default class MainContainer extends Component {
     }
   }
 
-  // TODO: big try/catch block
   async handleSelect(value, type) {
     const { handleUpdate } = this;
     const {

--- a/lib/SelectWallet.js
+++ b/lib/SelectWallet.js
@@ -7,6 +7,8 @@ import { Amount } from 'bcoin';
 
 // Third Party
 import _ from 'lodash';
+// TODO: pull this out
+import Immutable from 'seamless-immutable';
 
 // First Party
 import QRCode from './QRCode';
@@ -15,7 +17,7 @@ import { safeEval, preventDefault } from './utilities';
 // configuration
 import { PLUGIN_NAMESPACE, TXN_HISTORY_TABLE_VALUES, TXN_DISPLAY_COUNT  } from './constants';
 
-// TODO: import from single file
+// TODO: import styles from single file
 const styles = {
   inputStyle: { margin: '0.5rem' },
   selectListStyle: { margin: '0.5rem' },
@@ -30,7 +32,14 @@ class SelectWallet extends Component {
   }
 
   parseTxnHistory(transactions = []) {
-    const txns = transactions.slice(0, TXN_DISPLAY_COUNT);
+    // only grab the TXN_DISPLAY_COUNT most recent transactions
+    // TXN_DISPLAY_COUNT will never be too large of a number
+    const negated = ~TXN_DISPLAY_COUNT + 1;
+    console.assert(negated < TXN_DISPLAY_COUNT);
+
+    // TODO: remove Immutable
+    // reverse the list to display most recent first
+    const txns = Immutable.asMutable(transactions.slice(negated)).reverse();
     return txns.map(txn => {
       const t = _.pick(txn, TXN_HISTORY_TABLE_VALUES);
       // make sure all values are strings

--- a/lib/SelectWallet.js
+++ b/lib/SelectWallet.js
@@ -13,7 +13,7 @@ import QRCode from './QRCode';
 import { safeEval, preventDefault } from './utilities';
 
 // configuration
-import { PLUGIN_NAMESPACE, TXN_HISTORY_TABLE_VALUES  } from './constants';
+import { PLUGIN_NAMESPACE, TXN_HISTORY_TABLE_VALUES, TXN_DISPLAY_COUNT  } from './constants';
 
 // TODO: import from single file
 const styles = {
@@ -30,13 +30,14 @@ class SelectWallet extends Component {
   }
 
   parseTxnHistory(transactions = []) {
-    return transactions.map(txn => {
+    const txns = transactions.slice(0, TXN_DISPLAY_COUNT);
+    return txns.map(txn => {
       const t = _.pick(txn, TXN_HISTORY_TABLE_VALUES);
       // make sure all values are strings
       // to populate the table with appropriate values
       Object.keys(t).forEach(key => {
-        // sometimes the value is null
-        //
+        // sometimes the value is null but don't
+        // exclude 0 just because it is falsy
         if (t[key] || t[key] === 0) {
           t[key] = t[key].toString();
         } else {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -27,3 +27,6 @@ export const TXN_HISTORY_TABLE_VALUES = [
   'virtualSize'
 ];
 
+// HACK: until we have a paginating table
+export const TXN_DISPLAY_COUNT = 15;
+

--- a/lib/index.js
+++ b/lib/index.js
@@ -68,7 +68,6 @@ export const decoratePanel = (Panel, { React, PropTypes }) => {
   };
 };
 
-// TODO: still being passed through as parentProps...
 export const getRouteProps = {
   [metadata.name]: (parentProps, props) =>
     Object.assign(props, {
@@ -108,7 +107,6 @@ export const mapComponentState = {
     })
 };
 
-// https://www.npmjs.com/package/seamless-immutable
 export const reduceWallets = (state, action) => {
   const { type, payload = {} } = action;
   const {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "peerDependencies": {
     "@bpanel/bpanel-ui": "git+https://github.com/bpanel-org/bpanel-ui",
     "bcoin": "git+https://github.com/bcoin-org/bcoin.git",
-    "@bpanel/bpanel-utils": "git+https://github.com/bpanel-org/bpanel-utils"
+    "@bpanel/bpanel-utils": "git+https://github.com/bpanel-org/bpanel-utils",
+    "seamless-immutable": "^7.1.2"
   },
   "devDependencies": {
     "babel-preset-env": "^1.6.1",


### PR DESCRIPTION
Rendering thousands of transactions will break the browser, this is a temporary hack to prevent that from happening. Will render up to the `TXN_DISPLAY_COUNT`