### PR TITLE
Tx updates

### DIFF
--- a/lib/SelectWallet.js
+++ b/lib/SelectWallet.js
@@ -1,19 +1,29 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-
-import { Button, Header, Input, Table, Text } from '@bpanel/bpanel-ui';
+import {
+  Button,
+  Header,
+  Input,
+  Table,
+  Text,
+  ExpandedDataRow
+} from '@bpanel/bpanel-ui';
 import { Amount } from 'bcoin';
 
 // Third Party
-import _ from 'lodash';
+import { pick, omit } from 'lodash';
 
 // First Party
 import QRCode from './QRCode';
 import { safeEval, preventDefault } from './utilities';
 
 // configuration
-import { PLUGIN_NAMESPACE, TXN_HISTORY_TABLE_VALUES, TXN_DISPLAY_COUNT  } from './constants';
+import {
+  PLUGIN_NAMESPACE,
+  TXN_HISTORY_TABLE_VALUES,
+  TXN_DISPLAY_COUNT
+} from './constants';
 
 // TODO: import styles from single file
 const styles = {
@@ -84,7 +94,7 @@ class SelectWallet extends Component {
       pluginState: PropTypes.object,
       selectedWallet: PropTypes.string, // comes from plugin state
       selectedAccount: PropTypes.string, // comes from plugin state
-      receiveAddress: PropTypes.object,
+      receiveAddress: PropTypes.object
     };
   }
 
@@ -114,10 +124,36 @@ class SelectWallet extends Component {
     const accountTableData = this.buildSingleRowTable(accounts, 'Accounts');
 
     // evaluate safely in case undefined values exist
-    const _walletBalance = safeEval(() => new Amount(info[pluginState.selectedWallet].balance.confirmed).toBTC(), '');
-    const _accountBalance = safeEval(() => new Amount(balance[pluginState.selectedWallet][pluginState.selectedAccount].confirmed).toBTC(), '');
-    const _receiveAddress = safeEval(() => accountInfo[selectedWallet][selectedAccount].receiveAddress, '');
-    const _qrText = safeEval(() => accountInfo[selectedWallet][selectedAccount].receiveAddress, '');
+    const _walletBalance = safeEval(
+      () =>
+        new Amount(info[pluginState.selectedWallet].balance.confirmed).toBTC(),
+      ''
+    );
+    const _accountBalance = safeEval(
+      () =>
+        new Amount(
+          balance[pluginState.selectedWallet][
+            pluginState.selectedAccount
+          ].confirmed
+        ).toBTC(),
+      ''
+    );
+    const _receiveAddress = safeEval(
+      () => accountInfo[selectedWallet][selectedAccount].receiveAddress,
+      ''
+    );
+    const _qrText = safeEval(
+      () => accountInfo[selectedWallet][selectedAccount].receiveAddress,
+      ''
+    );
+    let expandedData = [{ mainData: [], subData: [] }];
+    if (txnHistory.length) {
+      const mainTxData = ['tx', 'hash', 'block'];
+      expandedData = txnHistory.map(tx => ({
+        mainData: pick(tx, mainTxData),
+        subData: omit(tx, mainTxData)
+      }));
+    }
 
     return (
       <div className="container">
@@ -153,7 +189,9 @@ class SelectWallet extends Component {
             <Button
               type="action"
               style={styles.wideButton}
-              onClick={() => handleCreate(this.props.accountNameInput.value, 'newAccount')}
+              onClick={() =>
+                handleCreate(this.props.accountNameInput.value, 'newAccount')
+              }
             >
               Create Account
             </Button>
@@ -163,15 +201,11 @@ class SelectWallet extends Component {
           {/* TODO: allow for conversions in BTC display units */}
           <div className="col-sm">
             <Header type="h4">Wallet Balance</Header>
-            <Text type="p">
-              {`Balance: ${_walletBalance} BTC`}
-            </Text>
+            <Text type="p">{`Balance: ${_walletBalance} BTC`}</Text>
           </div>
           <div className="col-sm">
             <Header type="h4">Account Balance</Header>
-            <Text type="p">
-              {`Balance: ${_accountBalance} BTC`}
-            </Text>
+            <Text type="p">{`Balance: ${_accountBalance} BTC`}</Text>
           </div>
         </div>
         {/* SEND SECTION */}
@@ -185,7 +219,9 @@ class SelectWallet extends Component {
               className="form-control"
               value={sendBalanceInput.value}
               style={styles.inputStyle}
-              onChange={e => handleUpdate(preventDefault(e).target.value, 'sendBalanceInput')}
+              onChange={e =>
+                handleUpdate(preventDefault(e).target.value, 'sendBalanceInput')
+              }
             />
             <Input
               type="text"
@@ -194,7 +230,9 @@ class SelectWallet extends Component {
               className="form-control"
               style={styles.inputStyle}
               value={recipientInput.value}
-              onChange={e => handleUpdate(preventDefault(e).target.value, 'recipientInput')}
+              onChange={e =>
+                handleUpdate(preventDefault(e).target.value, 'recipientInput')
+              }
             />
             <Input
               type="text"
@@ -203,7 +241,12 @@ class SelectWallet extends Component {
               className="form-control"
               style={styles.inputStyle}
               value={transactionFeeInput.value}
-              onChange={e => handleUpdate(preventDefault(e).target.value, 'transactionFeeInput')}
+              onChange={e =>
+                handleUpdate(
+                  preventDefault(e).target.value,
+                  'transactionFeeInput'
+                )
+              }
             />
             <Input
               type="text"
@@ -212,7 +255,12 @@ class SelectWallet extends Component {
               className="form-control"
               style={styles.inputStyle}
               value={sendWalletPassphraseInput.value}
-              onChange={e => handleUpdate(preventDefault(e).target.value, 'sendWalletPassphraseInput')}
+              onChange={e =>
+                handleUpdate(
+                  preventDefault(e).target.value,
+                  'sendWalletPassphraseInput'
+                )
+              }
             />
             <Button
               type="action"
@@ -229,20 +277,16 @@ class SelectWallet extends Component {
                     rate: transactionFeeInput.value
                   },
                   'sendTransaction'
-                )}
+                )
+              }
             >
               Send
             </Button>
           </div>
           <div className="col-sm">
             <Header type="h4">Receive</Header>
-            <Text type="p">
-              {`Address: ${_receiveAddress}`}
-            </Text>
-            <QRCode
-              containerStyle={styles.qrCodeContainer}
-              text={_qrText}
-            />
+            <Text type="p">{`Address: ${_receiveAddress}`}</Text>
+            <QRCode containerStyle={styles.qrCodeContainer} text={_qrText} />
             <Button
               type="action"
               style={styles.wideButton}
@@ -258,7 +302,9 @@ class SelectWallet extends Component {
             <Table
               colHeaders={TXN_HISTORY_TABLE_VALUES}
               tableData={txnHistory}
-              onRowClick={rowData => console.log(rowData)}
+              expandedData={expandedData}
+              expandedHeight={250}
+              ExpandedComponent={ExpandedDataRow}
             />
           </div>
         </div>

--- a/lib/SelectWallet.js
+++ b/lib/SelectWallet.js
@@ -41,22 +41,26 @@ class SelectWallet extends Component {
     this.mainTxCats = ['tx', 'hash', 'block'];
     this.txTableInit = <Text type="p">Must select a wallet and account to display transaction history</Text>;
     this.txTableLoading = <Text type="p">Loading transaction history...</Text>;
+    // only grab the TXN_DISPLAY_COUNT most recent transactions
+    // TXN_DISPLAY_COUNT will never be too large of a number
+    this.negatedTx = ~TXN_DISPLAY_COUNT + 1;
+    console.assert(this.negatedTx < TXN_DISPLAY_COUNT);
   }
 
   parseTxnHistory(transactions = []) {
-    // only grab the TXN_DISPLAY_COUNT most recent transactions
-    // TXN_DISPLAY_COUNT will never be too large of a number
-    const negated = ~TXN_DISPLAY_COUNT + 1;
-    console.assert(negated < TXN_DISPLAY_COUNT);
-    // reverse the list to display most recent first
+    // sort the list by confirmations and size
+    // then slice the back negatedTx amount of txs (least # of confirmations)
+    // and reverse the list (so most recent txs are at the top)
     const txns = transactions.sort((a, b) => {
-      // sort by confirmations
+      // put lower confirmations at higher index
       if (a.confirmations < b.confirmations) return 1;
       else if (a.confirmations > b.confirmations) return -1;
+      // if confirmations the same, sort by virtual size
       else if (a.virtualSize < b.virtualSize) return 1;
       else if (a.virtualSize > b.virtualSize) return -1;
       return 0;
-    }).slice(negated).reverse();
+    }).slice(this.negatedTx).reverse();
+
     return txns.map(txn => {
       const t = pick(txn, TXN_HISTORY_TABLE_VALUES);
       // make sure all values are strings

--- a/lib/SelectWallet.js
+++ b/lib/SelectWallet.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import {
@@ -34,7 +34,7 @@ const styles = {
   qrCodeContainer: { textAlign: 'center', margin: '0.5rem' }
 };
 
-class SelectWallet extends Component {
+class SelectWallet extends PureComponent {
   constructor(props) {
     super(props);
     this.loadingAccount = false;
@@ -162,9 +162,6 @@ class SelectWallet extends Component {
     );
     let expandedData = [{ mainData: [], subData: [] }];
 
-    if (txnHistory.length) {
-    }
-
     // Setup TX History table
     let txTable = this.txTableInit;
     if (selectedAccount && this.loadingAccount && !txnHistory.length) {
@@ -195,7 +192,7 @@ class SelectWallet extends Component {
               colHeaders={['Wallets']}
               styles={styles.selectListStyle}
               tableData={walletTableData}
-              onRowClick={e => handleSelect(e.rowData.Wallets, 'wallet')}
+              onRowClick={e => handleSelect(preventDefault(e).rowData.Wallets, 'wallet')}
             />
           </div>
           {/* ACCOUNTS SECTION */}
@@ -217,7 +214,7 @@ class SelectWallet extends Component {
               className="form-control"
               value={accountNameInput.value}
               style={styles.inputStyle}
-              onChange={e => handleUpdate(e.target.value, 'accountNameInput')}
+              onChange={e => handleUpdate(preventDefault(e).target.value, 'accountNameInput')}
             />
             <Button
               type="action"

--- a/lib/SelectWallet.js
+++ b/lib/SelectWallet.js
@@ -37,6 +37,7 @@ const styles = {
 class SelectWallet extends Component {
   constructor(props) {
     super(props);
+    this.loadingAccount = false;
   }
 
   parseTxnHistory(transactions = []) {
@@ -44,7 +45,6 @@ class SelectWallet extends Component {
     // TXN_DISPLAY_COUNT will never be too large of a number
     const negated = ~TXN_DISPLAY_COUNT + 1;
     console.assert(negated < TXN_DISPLAY_COUNT);
-
     // reverse the list to display most recent first
     const txns = transactions.slice(negated).reverse().sort((a, b) => {
       // sort by confirmations
@@ -55,7 +55,7 @@ class SelectWallet extends Component {
       return 0;
     });
     return txns.map(txn => {
-      const t = _.pick(txn, TXN_HISTORY_TABLE_VALUES);
+      const t = pick(txn, TXN_HISTORY_TABLE_VALUES);
       // make sure all values are strings
       // to populate the table with appropriate values
       Object.keys(t).forEach(key => {
@@ -154,14 +154,31 @@ class SelectWallet extends Component {
       ''
     );
     let expandedData = [{ mainData: [], subData: [] }];
+
     if (txnHistory.length) {
+    }
+
+    // Setup TX History table
+    let txTable = <Text type="p">Must select a wallet and account to display transaction history</Text>;
+    if (selectedAccount && this.loadingAccount && !txnHistory.length) {
+      txTable = <Text type="p">Loading transaction history...</Text>
+    } else if (selectedAccount && txnHistory.length){
+      this.loadingAccount = false;
       const mainTxData = ['tx', 'hash', 'block'];
       expandedData = txnHistory.map(tx => ({
         mainData: pick(tx, mainTxData),
         subData: omit(tx, mainTxData)
       }));
+      txTable = (
+        <Table
+          colHeaders={TXN_HISTORY_TABLE_VALUES}
+          tableData={txnHistory}
+          expandedData={expandedData}
+          expandedHeight={250}
+          ExpandedComponent={ExpandedDataRow}
+        />
+      );
     }
-
     return (
       <div className="container">
         <div className="row" style={styles.componentContainer}>
@@ -182,7 +199,10 @@ class SelectWallet extends Component {
               colHeaders={['Accounts']}
               styles={styles.selectListStyle}
               tableData={accountTableData}
-              onRowClick={e => handleSelect(e.rowData.Accounts, 'account')}
+              onRowClick={e => {
+                this.loadingAccount = true;
+                handleSelect(e.rowData.Accounts, 'account');
+              }}
             />
             <Input
               type="text"
@@ -306,13 +326,7 @@ class SelectWallet extends Component {
         <div className="row" styles={styles.componentContainer}>
           <div className="col-sm">
             <Header type="h4">Transaction History</Header>
-            <Table
-              colHeaders={TXN_HISTORY_TABLE_VALUES}
-              tableData={txnHistory}
-              expandedData={expandedData}
-              expandedHeight={250}
-              ExpandedComponent={ExpandedDataRow}
-            />
+            { txTable }
           </div>
         </div>
       </div>

--- a/lib/SelectWallet.js
+++ b/lib/SelectWallet.js
@@ -46,7 +46,14 @@ class SelectWallet extends Component {
     console.assert(negated < TXN_DISPLAY_COUNT);
 
     // reverse the list to display most recent first
-    const txns = transactions.slice(negated).reverse();
+    const txns = transactions.slice(negated).reverse().sort((a, b) => {
+      // sort by confirmations
+      if (a.confirmations > b.confirmations) return 1;
+      else if (a.confirmations < b.confirmations) return -1;
+      else if (a.virtualSize > b.virtualSize) return 1;
+      else if (a.virtualSize < b.virtualSize) return -1;
+      return 0;
+    });
     return txns.map(txn => {
       const t = _.pick(txn, TXN_HISTORY_TABLE_VALUES);
       // make sure all values are strings

--- a/lib/SelectWallet.js
+++ b/lib/SelectWallet.js
@@ -38,6 +38,9 @@ class SelectWallet extends Component {
   constructor(props) {
     super(props);
     this.loadingAccount = false;
+    this.mainTxCats = ['tx', 'hash', 'block'];
+    this.txTableInit = <Text type="p">Must select a wallet and account to display transaction history</Text>;
+    this.txTableLoading = <Text type="p">Loading transaction history...</Text>;
   }
 
   parseTxnHistory(transactions = []) {
@@ -46,14 +49,14 @@ class SelectWallet extends Component {
     const negated = ~TXN_DISPLAY_COUNT + 1;
     console.assert(negated < TXN_DISPLAY_COUNT);
     // reverse the list to display most recent first
-    const txns = transactions.slice(negated).reverse().sort((a, b) => {
+    const txns = transactions.sort((a, b) => {
       // sort by confirmations
-      if (a.confirmations > b.confirmations) return 1;
-      else if (a.confirmations < b.confirmations) return -1;
-      else if (a.virtualSize > b.virtualSize) return 1;
-      else if (a.virtualSize < b.virtualSize) return -1;
+      if (a.confirmations < b.confirmations) return 1;
+      else if (a.confirmations > b.confirmations) return -1;
+      else if (a.virtualSize < b.virtualSize) return 1;
+      else if (a.virtualSize > b.virtualSize) return -1;
       return 0;
-    });
+    }).slice(negated).reverse();
     return txns.map(txn => {
       const t = pick(txn, TXN_HISTORY_TABLE_VALUES);
       // make sure all values are strings
@@ -159,15 +162,14 @@ class SelectWallet extends Component {
     }
 
     // Setup TX History table
-    let txTable = <Text type="p">Must select a wallet and account to display transaction history</Text>;
+    let txTable = this.txTableInit;
     if (selectedAccount && this.loadingAccount && !txnHistory.length) {
-      txTable = <Text type="p">Loading transaction history...</Text>
+      txTable = this.txTableLoading;
     } else if (selectedAccount && txnHistory.length){
       this.loadingAccount = false;
-      const mainTxData = ['tx', 'hash', 'block'];
       expandedData = txnHistory.map(tx => ({
-        mainData: pick(tx, mainTxData),
-        subData: omit(tx, mainTxData)
+        mainData: pick(tx, this.mainTxCats),
+        subData: omit(tx, this.mainTxCats)
       }));
       txTable = (
         <Table

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -24,6 +24,7 @@ export const TXN_HISTORY_TABLE_VALUES = [
   'fee',
   'hash',
   'tx',
+  'height',
   'virtualSize'
 ];
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -34,5 +34,5 @@ export const TXN_HISTORY_TABLE_VALUES = [
 export const EXTRA_VERBOSE = false;
 
 // HACK: until we have a paginating table
-export const TXN_DISPLAY_COUNT = 15;
+export const TXN_DISPLAY_COUNT = 100;
 

--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
   "dependencies": {
     "babel-cli": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
-    "lodash": "^4.17.5",
     "qr-image": "^3.2.0"
   },
   "peerDependencies": {
     "@bpanel/bpanel-ui": "git+https://github.com/bpanel-org/bpanel-ui",
-    "bcoin": "git+https://github.com/bcoin-org/bcoin.git",
     "@bpanel/bpanel-utils": "git+https://github.com/bpanel-org/bpanel-utils",
+    "bcoin": "git+https://github.com/bcoin-org/bcoin.git",
+    "lodash": "^4.17.5",
     "react": "^16.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Some fixes for multisig mvp:

- sort transactions first by confirmations and then by size
- show message to select an account before tx history is shown
- show loading message while fetching tx history
- increase number of txs shown to 100 (tx history and range fetching don't work well and need to be fixed. in the meantime, instead of getting the last month of transactions 100 should be ok).