### PR TITLE
point bpanel peer deps to npm packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "qr-image": "^3.2.0"
   },
   "peerDependencies": {
-    "@bpanel/bpanel-ui": "git+https://github.com/bpanel-org/bpanel-ui",
-    "@bpanel/bpanel-utils": "git+https://github.com/bpanel-org/bpanel-utils",
+    "@bpanel/bpanel-ui": "^0.0.7",
+    "@bpanel/bpanel-utils": "^0.0.9",
     "bcoin": "git+https://github.com/bcoin-org/bcoin.git",
     "lodash": "^4.17.5",
     "react": "^16.2.0"


### PR DESCRIPTION
Might have been causing problems in docker container npm install. Not sure if this is necessarily why but `bpanel-utils` gets uninstalled when the plugins get installed in the docker container. 