### PR TITLE
use Currency for balance amounts

### DIFF
--- a/lib/Containers/SelectWallet.js
+++ b/lib/Containers/SelectWallet.js
@@ -11,7 +11,7 @@ import {
   QRCode,
 } from '@bpanel/bpanel-ui';
 import assert from 'bsert';
-import { Amount } from 'bcoin';
+import { Currency } from '@bpanel/bpanel-utils';
 
 // Third Party
 import { pick, omit } from 'lodash';
@@ -361,14 +361,20 @@ const mapStateToProps = (state, otherProps) => {
   const info = state.wallets.info;
   const balance = state.wallets.balance;
   const history = state.wallets.history;
-
+  const chain = state.clients.currentClient.chain;
   const walletBalance = safeEval(
-    () => new Amount(info[selectedWallet].balance.confirmed).toBTC(),
+    () =>
+      new Currency(chain, info[selectedWallet].balance.confirmed).to(
+        'currency'
+      ),
     ''
   );
   const accountBalance = safeEval(
     () =>
-      new Amount(balance[selectedWallet][selectedAccount].confirmed).toBTC(),
+      new Currency(
+        chain,
+        balance[selectedWallet][selectedAccount].confirmed
+      ).to('currency'),
     ''
   );
   const transactionHistory = safeEval(


### PR DESCRIPTION
Wasn't rendering amounts correctly for handshake balances. This uses `Currency` instead of `Amount`