### PR TITLE
UI: Wallet/Account selection tables

### DIFF
--- a/lib/Containers/SelectWallet.js
+++ b/lib/Containers/SelectWallet.js
@@ -197,6 +197,7 @@ class SelectWallet extends Component {
               onRowClick={e =>
                 handleSelect(preventDefault(e).rowData.Wallets, 'wallet')
               }
+              selectable={true}
             />
           </div>
           {/* ACCOUNTS SECTION */}
@@ -210,6 +211,7 @@ class SelectWallet extends Component {
                 this.loadingAccount = true;
                 handleSelect(preventDefault(e).rowData.Accounts, 'account');
               }}
+              selectable={true}
             />
             <Input
               type="text"


### PR DESCRIPTION
Adding `selectable={true}` to the wallet and account tables makes the UI a bit more familiar: cursor changes to pointer on hover and "selected" rows are better indicated.

Depends on: https://github.com/bpanel-org/bpanel-ui/pull/39 and https://github.com/bpanel-org/bpanel/pull/125