### PR TITLE
UI: Selectable table and get history on select account

### DIFF
--- a/lib/Containers/ActionWrapper.js
+++ b/lib/Containers/ActionWrapper.js
@@ -294,6 +294,7 @@ class ActionContainer extends Component {
           selectAccount('default');
           getAccountInfo(value, 'default');
           getAccountBalance(value, 'default');
+          getHistory(value, 'default');
           // reset the account name input to being empty
           handleFieldUpdate('', 'accountNameInput');
           break;

--- a/lib/Containers/SelectWallet.js
+++ b/lib/Containers/SelectWallet.js
@@ -151,8 +151,8 @@ class SelectWallet extends Component {
       recipientInput,
       transactionFeeInput,
       sendWalletPassphraseInput,
-      resetSelectedAccount,
-      resetSelectedWallet,
+      setSelectedAccount,
+      setSelectedWallet,
     } = this.props;
 
     const currencyUnit = currency ? currency.getUnit('unit').toUpperCase() : '';
@@ -200,7 +200,7 @@ class SelectWallet extends Component {
                 handleSelect(preventDefault(e).rowData.Wallets, 'wallet')
               }
               selectable={true}
-              reset={resetSelectedWallet}
+              setSelectedIndex={setSelectedWallet}
             />
           </div>
           {/* ACCOUNTS SECTION */}
@@ -215,7 +215,7 @@ class SelectWallet extends Component {
                 handleSelect(preventDefault(e).rowData.Accounts, 'account');
               }}
               selectable={true}
-              reset={resetSelectedAccount}
+              setSelectedIndex={setSelectedAccount}
             />
             <Input
               type="text"
@@ -357,8 +357,8 @@ class SelectWallet extends Component {
 const mapStateToProps = (state, otherProps) => {
   const pluginState = state.plugins[PLUGIN_NAMESPACE] || {};
   const {
-    resetSelectedAccount,
-    resetSelectedWallet,
+    setSelectedAccount,
+    setSelectedWallet,
     selectedAccount,
     selectedWallet,
     textFields = {}
@@ -416,8 +416,8 @@ const mapStateToProps = (state, otherProps) => {
     recipientInput,
     transactionFeeInput,
     sendWalletPassphraseInput,
-    resetSelectedAccount,
-    resetSelectedWallet,
+    setSelectedAccount,
+    setSelectedWallet,
     ...otherProps,
   };
 };

--- a/lib/Containers/SelectWallet.js
+++ b/lib/Containers/SelectWallet.js
@@ -151,6 +151,8 @@ class SelectWallet extends Component {
       recipientInput,
       transactionFeeInput,
       sendWalletPassphraseInput,
+      resetSelectedAccount,
+      resetSelectedWallet,
     } = this.props;
 
     const currencyUnit = currency ? currency.getUnit('unit').toUpperCase() : '';
@@ -198,6 +200,7 @@ class SelectWallet extends Component {
                 handleSelect(preventDefault(e).rowData.Wallets, 'wallet')
               }
               selectable={true}
+              reset={resetSelectedWallet}
             />
           </div>
           {/* ACCOUNTS SECTION */}
@@ -212,6 +215,7 @@ class SelectWallet extends Component {
                 handleSelect(preventDefault(e).rowData.Accounts, 'account');
               }}
               selectable={true}
+              reset={resetSelectedAccount}
             />
             <Input
               type="text"
@@ -352,7 +356,13 @@ class SelectWallet extends Component {
 
 const mapStateToProps = (state, otherProps) => {
   const pluginState = state.plugins[PLUGIN_NAMESPACE] || {};
-  const { selectedAccount, selectedWallet, textFields = {} } = pluginState;
+  const {
+    resetSelectedAccount,
+    resetSelectedWallet,
+    selectedAccount,
+    selectedWallet,
+    textFields = {}
+  } = pluginState;
   const accounts = state.wallets.accounts;
   const receiveAddress = safeEval(
     () =>
@@ -392,7 +402,6 @@ const mapStateToProps = (state, otherProps) => {
     transactionFeeInput = { value: '', valid: true },
     sendWalletPassphraseInput = { value: '', valid: true },
   } = textFields;
-
   return {
     wallets: state.wallets.wallets,
     accounts,
@@ -407,6 +416,8 @@ const mapStateToProps = (state, otherProps) => {
     recipientInput,
     transactionFeeInput,
     sendWalletPassphraseInput,
+    resetSelectedAccount,
+    resetSelectedWallet,
     ...otherProps,
   };
 };

--- a/lib/reducers/wallets.js
+++ b/lib/reducers/wallets.js
@@ -10,6 +10,7 @@ import {
 const initialState = {
   selectedWallet: 'primary',
   selectedAccount: 'default',
+  resetSelectedWallet: true,
   textFields: {},
 };
 
@@ -30,9 +31,12 @@ export default function walletsReducer(state = initialState, action) {
   switch (type) {
     case USER_SELECT_WALLET:
       newState.selectedWallet = walletId;
+      newState.resetSelectedAccount = true;
+      newState.resetSelectedWallet = false;
       return newState;
     case USER_SELECT_ACCOUNT:
       newState.selectedAccount = accountId;
+      newState.resetSelectedAccount = false;
       return newState;
     case USER_SELECT_MULTISIG_WALLET:
       newState.selectedMultisigWallet = walletId;

--- a/lib/reducers/wallets.js
+++ b/lib/reducers/wallets.js
@@ -10,7 +10,7 @@ import {
 const initialState = {
   selectedWallet: 'primary',
   selectedAccount: 'default',
-  resetSelectedWallet: true,
+  setSelectedWallet: 0,
   textFields: {},
 };
 
@@ -31,12 +31,12 @@ export default function walletsReducer(state = initialState, action) {
   switch (type) {
     case USER_SELECT_WALLET:
       newState.selectedWallet = walletId;
-      newState.resetSelectedAccount = true;
-      newState.resetSelectedWallet = false;
+      newState.setSelectedAccount = 0;
+      newState.setSelectedWallet = -1;
       return newState;
     case USER_SELECT_ACCOUNT:
       newState.selectedAccount = accountId;
-      newState.resetSelectedAccount = false;
+      newState.setSelectedAccount = -1;
       return newState;
     case USER_SELECT_MULTISIG_WALLET:
       newState.selectedMultisigWallet = walletId;


### PR DESCRIPTION
This is the last set of updates based on https://github.com/bpanel-org/bpanel-ui/pull/39 and https://github.com/bpanel-org/bpanel/pull/125

Selecting a wallet now automatically gets tx history for `default` account, which is selected automatically on select wallet.

Uses the new `setSelectedIndex` property on Table to provide visual feedback on wallet and account switching.